### PR TITLE
feat: initialize Go module and project structure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,32 @@
+# If you prefer the allow list template instead of the deny list, see community template:
+# https://github.com/github/gitignore/blob/main/community/Golang/Go.AllowList.gitignore
+#
+# Binaries for programs and plugins
+*.exe
+*.exe~
+*.dll
+*.so
+*.dylib
+
+# Test binary, built with `go test -c`
+*.test
+
+# Code coverage profiles and other test artifacts
+*.out
+coverage.*
+*.coverprofile
+profile.cov
+
+# Dependency directories (remove the comment below to include it)
+# vendor/
+
+# Go workspace file
+go.work
+go.work.sum
+
+# env file
+.env
+
+# Editor/IDE
+# .idea/
+# .vscode/

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/DarsenOP/Rift
+
+go 1.24.6


### PR DESCRIPTION
## Description

This PR lays the foundational structure for the Rift project by initializing the Go module and creating the standard directory layout. This is the first step in the "Foundation & Setup" milestone.

## Changes

- Initialized the Go module: `go mod init github.com/DarsenOP/Rift`
- Created the standard project directory structure:
  - `cmd/rift/` for the main application binary
  - `internal/` for private application code
  - `pkg/` for public, importable packages
  - `scripts/` for utility scripts
- Added a standard Go .gitignore file

## How to Test

- Check out this branch: `feat/setup-init-go-module`
- Run `go mod verify` to confirm the module is set up correctly.
- Verify the directory structure matches the intended layout.

## Related Issues

- Completes part of the milestone: **Foundation & Setup**
- Closes #1