### PR TITLE
fix: isolate CI caches per branch to prevent corruption

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -23,15 +23,16 @@ jobs:
         cache: true
         cache-dependency-path: go.sum
 
-    # Step 3: Cache Go module downloads (REPLACES the broad cache)
+    # Step 3: Cache Go module downloads
     - name: Cache Go Modules
       uses: actions/cache@v3
       with:
         path: |
           ~/.cache/go-build
           ~/go/pkg/mod
-        key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+        key: ${{ runner.os }}-go-${{ github.ref }}-${{ hashFiles('**/go.sum') }}
         restore-keys: |
+          ${{ runner.os }}-go-${{ github.ref }}-
           ${{ runner.os }}-go-
 
     # Step 4: Cache installed tools specifically
@@ -40,7 +41,7 @@ jobs:
       id: tools-cache
       with:
         path: ~/go/bin
-        key: ${{ runner.os }}-go-tools-${{ hashFiles('**/go.sum') }}
+        key: ${{ runner.os }}-go-tools-${{ github.ref }}-${{ hashFiles('**/go.sum') }}
 
     # Step 5: Install the necessary tools ONLY if not cached
     - name: Install tools


### PR DESCRIPTION
## Description

This PR fixes a critical cache collision issue where different branches were sharing corrupted cache artifacts, causing "Cannot open: File exists" errors. The solution isolates caches per branch while maintaining performance benefits.
Root Cause

The cache key was based only on go.sum hash, causing different branches with the same dependencies to share cache storage, including previously corrupted caches.

## Changes

- Added branch isolation: Modified cache keys in `.github/workflows/go.yml` to include `${{ github.ref }}`
- Maintained performance: Kept all caching optimizations while fixing isolation
- Added fallback strategy: Implemented proper restore-keys for cross-branch cache sharing when safe

## Verification

- Cache keys now include branch context: Linux-go-refs/heads/feat/setup-tooling-...
- Prevents cross-branch cache contamination
- Maintains caching benefits within the same branch