### PR TITLE
Feat/setup tooling

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -23,27 +23,15 @@ jobs:
         cache: true
         cache-dependency-path: go.sum
 
-    # Step 3: Cache Go module downloads - USING FRESH KEY
-    - name: Cache Go Modules
-      uses: actions/cache@v3
-      with:
-        path: |
-          ~/.cache/go-build
-          ~/go/pkg/mod
-        key: ${{ runner.os }}-go-FRESH-START-${{ github.ref }}-${{ hashFiles('**/go.sum') }}
-        restore-keys: |
-          ${{ runner.os }}-go-FRESH-START-${{ github.ref }}-
-          ${{ runner.os }}-go-FRESH-START-
-
-    # Step 4: Cache installed tools - USING FRESH KEY
-    - name: Cache Go Tools
+    # Step 3: Cache installed tools - USING FRESH KEY
+    - name: Cache Go tools
       uses: actions/cache@v3
       id: tools-cache
       with:
         path: ~/go/bin
-        key: ${{ runner.os }}-go-tools-FRESH-START-${{ github.ref }}-${{ hashFiles('**/go.sum') }}
+        key: ${{ runner.os }}-go-tools-${{ hashFiles('**/go.sum') }}
 
-    # Step 5: Install the necessary tools ONLY if not cached
+    # Step 4: Install the necessary tools ONLY if not cached
     - name: Install tools
       if: steps.tools-cache.outputs.cache-hit != 'true'
       run: |


### PR DESCRIPTION
## Description

This PR fixes the cache collision issue where the CI pipeline fails with "Cannot open: File exists" errors due to overlapping caches between setup-go and actions/cache.

## Root Cause

actions/setup-go@v4 already restores its own comprehensive cache (both GOMODCACHE and GOCACHE) based on the Go version and go.sum hash. The subsequent actions/cache@v3 steps attempted to restore the same directories, causing file conflicts when the second cache tried to overwrite already-populated read-only files.

## Changes

- Removed redundant cache steps: Eliminated the duplicate actions/cache@v3 for `~/.cache/go-build` and `~/go/pkg/mod`
- Preserved tool caching: Kept the `~/go/bin` cache for tools like `gofumpt` and `golangci-lint` to maintain fast tool installation
- Maintained cache benefits: setup-go's built-in caching provides identical performance without conflicts

## Verification

- CI now runs without "Cannot open: File exists" errors
- Cache keys no longer conflict between setup-go and custom cache steps
- Tool installation remains fast via preserved `~/go/bin` cache

