### PR TITLE
fix: run the make fmt before pushing and PR

### DIFF
--- a/scripts/validate_structure.go
+++ b/scripts/validate_structure.go
@@ -13,29 +13,29 @@ func main() {
 		"pkg",
 		"scripts",
 	}
-	
+
 	requiredFiles := []string{
 		"cmd/rift/main.go",
 		"go.mod",
-		"go.sum", 
+		"go.sum",
 		"Makefile",
 		".golangci.yml",
 		".github/workflows/go.yml",
 	}
-	
+
 	allGood := true
-	
+
 	// Check directories
 	for _, dir := range requiredDirs {
 		if info, err := os.Stat(dir); os.IsNotExist(err) {
 			fmt.Printf("xxx Missing directory: %s\n", dir)
 			allGood = false
 		} else if !info.IsDir() {
-			fmt.Printf("xxx Not a directory: %s\n", dir)	
+			fmt.Printf("xxx Not a directory: %s\n", dir)
 			allGood = false
 		}
 	}
-	
+
 	// Check files
 	for _, file := range requiredFiles {
 		if info, err := os.Stat(file); os.IsNotExist(err) {
@@ -46,7 +46,7 @@ func main() {
 			allGood = false
 		}
 	}
-	
+
 	if allGood {
 		fmt.Println("--- Project structure is valid!")
 		os.Exit(0)


### PR DESCRIPTION
## Description

This PR fixes a CI validation failure where the `make fmt` failed, because it was not done locally before pushing.

## Root Cause

`make fmt` was not run locally because of that, there were issues with formatting and the CI didn't pass the formatting test.

## Solution

Run the `make fmt` locally and pushed it to the repo

- Ensures all the files are in a good formatting
- Maintains the directory's purpose as private code storage
- Doesn't affect build or functionality
- Allows CI validation to pass

## Changes

- Modified `./scripts/validate_structure.go` for the right formatting

## Verification

- CI validation will now pass