### PR TITLE
feat: add thread-safe in-memory store

### DIFF
--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -1,0 +1,46 @@
+package storage
+
+import "sync"
+
+// Store is a simple, thread-safe in-memory string-to-string store.
+type Store struct {
+	mu   sync.RWMutex
+	data map[string]string
+}
+
+// New returns an empty Store ready for use.
+func New() *Store {
+	return &Store{data: make(map[string]string)}
+}
+
+// Set writes or overwrites a key with the given value.
+func (s *Store) Set(key, value string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.data[key] = value
+}
+
+// Get returns the value and true if the key exists; otherwise (“”, false).
+func (s *Store) Get(key string) (string, bool) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	v, ok := s.data[key]
+	return v, ok
+}
+
+// Del removes the key and returns true if it was present.
+func (s *Store) Del(key string) bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	_, ok := s.data[key]
+	delete(s.data, key)
+	return ok
+}
+
+// Exists reports whether the key is present.
+func (s *Store) Exists(key string) bool {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	_, ok := s.data[key]
+	return ok
+}

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -1,0 +1,55 @@
+package storage
+
+import (
+	"sync"
+	"testing"
+)
+
+func TestBasicCRUD(t *testing.T) {
+	s := New()
+
+	// Initial state
+	if v, ok := s.Get("k"); ok || v != "" {
+		t.Fatalf("expected empty, got %q %v", v, ok)
+	}
+	if s.Exists("k") {
+		t.Fatal("key should not exist")
+	}
+
+	s.Set("k", "v")
+	if v, ok := s.Get("k"); !ok || v != "v" {
+		t.Fatalf("expected v=true, got %q %v", v, ok)
+	}
+	if !s.Exists("k") {
+		t.Fatal("key should exist")
+	}
+
+	if !s.Del("k") {
+		t.Fatal("Del should return true")
+	}
+	if s.Exists("k") {
+		t.Fatal("key should be gone")
+	}
+}
+
+func TestConcurrentAccess(t *testing.T) {
+	s := New()
+	const workers = 100
+	const opsPerWorker = 1000
+
+	var wg sync.WaitGroup
+	wg.Add(workers)
+	for i := 0; i < workers; i++ {
+		go func(id int) {
+			defer wg.Done()
+			for j := 0; j < opsPerWorker; j++ {
+				key := string(rune('A' + (id+j)%26))
+				s.Set(key, key)
+				s.Get(key)
+				s.Exists(key)
+				s.Del(key)
+			}
+		}(i)
+	}
+	wg.Wait()
+}


### PR DESCRIPTION
Implements the very first slice of Phase 2: a simple, thread-safe in-memory key/value store.

- New package: internal/storage
- Type: storage.Store
- Thread-safety via sync.RWMutex
- Methods exposed:
  - Set(key, value string)
  - Get(key) (string, bool)
  - Del(key) (deleted bool)
  - Exists(key) bool
- Unit tests cover:
  - Basic CRUD flows
  - 100-goroutine concurrent access (race-free)
- No persistence, expiration, or RESP command logic yet

All tests pass (`make test`). CI should be green after the merge. 
Closes #35 