### PR TITLE
feat: implement GET command

### DIFF
--- a/internal/server/handler.go
+++ b/internal/server/handler.go
@@ -28,6 +28,8 @@ func HandleCommand(store *storage.Store, value resp.Value) resp.Value {
 		return HandleCOMMAND()
 	case "SET":
 		return HandleSET(store, value.Array[1:])
+	case "GET":
+		return HandleGET(store, value.Array[1:])
 	default:
 		return resp.Value{Typ: "error", Str: "ERR unknown command '" + command.Str + "'"}
 	}
@@ -67,4 +69,22 @@ func HandleSET(store *storage.Store, args []resp.Value) resp.Value {
 
 	store.Set(args[0].Str, args[1].Str)
 	return resp.Value{Typ: "simple", Str: "OK"}
+}
+
+func HandleGET(store *storage.Store, args []resp.Value) resp.Value {
+	if len(args) != 1 {
+		return resp.Value{Typ: "error", Str: "ERR wrong number of arguments for 'get' command"}
+	}
+
+	if args[0].Typ != "bulk" {
+		return resp.Value{Typ: "error", Str: "ERR argument should be a bulk string"}
+	}
+
+	value, ok := store.Get(args[0].Str)
+
+	if !ok || value == "" {
+		return resp.Value{Typ: "null", NullTyp: "bulk"}
+	}
+
+	return resp.Value{Typ: "bulk", Str: value}
 }

--- a/internal/server/handler_test.go
+++ b/internal/server/handler_test.go
@@ -139,6 +139,51 @@ func TestHandleCommand(t *testing.T) {
 			},
 			expected: resp.Value{Typ: "error", Str: "ERR arguments should be bulk strings"},
 		},
+		{
+			name: "GET missing key",
+			input: resp.Value{
+				Typ: "array",
+				Array: []resp.Value{
+					{Typ: "bulk", Str: "GET"},
+					{Typ: "bulk", Str: "nosuch"},
+				},
+			},
+			expected: resp.Value{Typ: "null", NullTyp: "bulk"}, // $-1\r\n
+		},
+		{
+			name: "GET existing key",
+			input: resp.Value{
+				Typ: "array",
+				Array: []resp.Value{
+					{Typ: "bulk", Str: "GET"},
+					{Typ: "bulk", Str: "mykey"},
+				},
+			},
+			expected: resp.Value{Typ: "bulk", Str: "myvalue"},
+		},
+		{
+			name: "GET wrong arity",
+			input: resp.Value{
+				Typ: "array",
+				Array: []resp.Value{
+					{Typ: "bulk", Str: "GET"},
+					{Typ: "bulk", Str: "k1"},
+					{Typ: "bulk", Str: "k2"},
+				},
+			},
+			expected: resp.Value{Typ: "error", Str: "ERR wrong number of arguments for 'get' command"},
+		},
+		{
+			name: "GET non-bulk key",
+			input: resp.Value{
+				Typ: "array",
+				Array: []resp.Value{
+					{Typ: "bulk", Str: "GET"},
+					{Typ: "integer", Num: 123},
+				},
+			},
+			expected: resp.Value{Typ: "error", Str: "ERR argument should be a bulk string"},
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
Adds the read-side companion to SET: the Redis-compatible GET command.

## What changed

- `internal/server/handler.go`
  - new `HandleGET` helper
  - validates arity (exactly 1 bulk arg)
  - returns `$-1\r\n` for missing key, bulk-string for existing key
- `internal/server/handler_test.go`
  - table rows for GET: missing key, existing key, arity error, non-bulk arg

All existing tests pass (make test).

Closes #37 