### PR TITLE
feat: implement DEL command

### DIFF
--- a/internal/server/handler.go
+++ b/internal/server/handler.go
@@ -30,6 +30,8 @@ func HandleCommand(store *storage.Store, value resp.Value) resp.Value {
 		return HandleSET(store, value.Array[1:])
 	case "GET":
 		return HandleGET(store, value.Array[1:])
+	case "DEL":
+		return HandleDEL(store, value.Array[1:])
 	default:
 		return resp.Value{Typ: "error", Str: "ERR unknown command '" + command.Str + "'"}
 	}
@@ -87,4 +89,24 @@ func HandleGET(store *storage.Store, args []resp.Value) resp.Value {
 	}
 
 	return resp.Value{Typ: "bulk", Str: value}
+}
+
+func HandleDEL(store *storage.Store, args []resp.Value) resp.Value {
+	if len(args) == 0 {
+		return resp.Value{Typ: "error", Str: "ERR wrong number of arguments for 'del' command"}
+	}
+
+	for _, arg := range args {
+		if arg.Typ != "bulk" {
+			return resp.Value{Typ: "error", Str: "ERR arguments should be bulk strings"}
+		}
+	}
+
+	deleted := 0
+	for _, arg := range args {
+		if store.Del(arg.Str) {
+			deleted++
+		}
+	}
+	return resp.Value{Typ: "integer", Num: deleted}
 }

--- a/internal/server/handler_test.go
+++ b/internal/server/handler_test.go
@@ -95,12 +95,24 @@ func TestHandleCommand(t *testing.T) {
 			expected: resp.Value{Typ: "error", Str: "ERR command must be a bulk string"},
 		},
 		{
-			name: "SET OK",
+			name: "SET OK 1",
 			input: resp.Value{
 				Typ: "array",
 				Array: []resp.Value{
 					{Typ: "bulk", Str: "SET"},
 					{Typ: "bulk", Str: "mykey"},
+					{Typ: "bulk", Str: "myvalue"},
+				},
+			},
+			expected: resp.Value{Typ: "simple", Str: "OK"},
+		},
+		{
+			name: "SET OK 2",
+			input: resp.Value{
+				Typ: "array",
+				Array: []resp.Value{
+					{Typ: "bulk", Str: "SET"},
+					{Typ: "bulk", Str: "mykey2"},
 					{Typ: "bulk", Str: "myvalue"},
 				},
 			},
@@ -183,6 +195,60 @@ func TestHandleCommand(t *testing.T) {
 				},
 			},
 			expected: resp.Value{Typ: "error", Str: "ERR argument should be a bulk string"},
+		},
+		{
+			name: "DEL one existing",
+			input: resp.Value{
+				Typ: "array",
+				Array: []resp.Value{
+					{Typ: "bulk", Str: "DEL"},
+					{Typ: "bulk", Str: "mykey"},
+				},
+			},
+			expected: resp.Value{Typ: "integer", Num: 1},
+		},
+		{
+			name: "DEL two, one missing",
+			input: resp.Value{
+				Typ: "array",
+				Array: []resp.Value{
+					{Typ: "bulk", Str: "DEL"},
+					{Typ: "bulk", Str: "mykey2"},
+					{Typ: "bulk", Str: "nosuch"},
+				},
+			},
+			expected: resp.Value{Typ: "integer", Num: 1},
+		},
+		{
+			name: "DEL multiple all missing",
+			input: resp.Value{
+				Typ: "array",
+				Array: []resp.Value{
+					{Typ: "bulk", Str: "DEL"},
+					{Typ: "bulk", Str: "nosuch1"},
+					{Typ: "bulk", Str: "nosuch2"},
+				},
+			},
+			expected: resp.Value{Typ: "integer", Num: 0},
+		},
+		{
+			name: "DEL no args",
+			input: resp.Value{
+				Typ:   "array",
+				Array: []resp.Value{{Typ: "bulk", Str: "DEL"}},
+			},
+			expected: resp.Value{Typ: "error", Str: "ERR wrong number of arguments for 'del' command"},
+		},
+		{
+			name: "DEL non-bulk key",
+			input: resp.Value{
+				Typ: "array",
+				Array: []resp.Value{
+					{Typ: "bulk", Str: "DEL"},
+					{Typ: "integer", Num: 123},
+				},
+			},
+			expected: resp.Value{Typ: "error", Str: "ERR arguments should be bulk strings"},
 		},
 	}
 


### PR DESCRIPTION
Adds the Redis-compatible `DEL key [key ...]` command.

## What changed

- `HandleDEL` validates arity & bulk types in first pass, deletes in second
- Returns integer reply: count of keys actually removed
- Wired into dispatcher switch
- New table rows in `handler_test.go` cover single, multiple, missing, error cases

All tests green (make test).

Closes #38 