### PR TITLE
feat: add per-key expiration engine & janitor

### DIFF
--- a/internal/storage/store.go
+++ b/internal/storage/store.go
@@ -1,30 +1,96 @@
 package storage
 
-import "sync"
+import (
+	"sync"
+	"time"
+)
 
 // Store is a simple, thread-safe in-memory string-to-string store.
 type Store struct {
 	mu   sync.RWMutex
 	data map[string]string
+	exps map[string]time.Time
+
+	stopJanitor chan struct{}
 }
 
 // New returns an empty Store ready for use.
 func New() *Store {
-	return &Store{data: make(map[string]string)}
+	s := &Store{
+		data:        make(map[string]string),
+		exps:        make(map[string]time.Time),
+		stopJanitor: make(chan struct{}),
+	}
+
+	go s.janitor()
+	return s
+}
+
+// Shutdown stops the background janitor goroutine.
+// Idempotent; safe to call multiple times.
+func (s *Store) Shutdown() {
+	s.mu.Lock()
+
+	select {
+	case <-s.stopJanitor:
+	default:
+		close(s.stopJanitor)
+	}
+
+	s.mu.Unlock()
+}
+
+// janitor wakes every 100 ms and deletes expired keys.
+func (s *Store) janitor() {
+	ticker := time.NewTicker(100 * time.Millisecond)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ticker.C:
+			s.deleteExpired()
+		case <-s.stopJanitor:
+			return
+		}
+	}
+}
+
+func (s *Store) deleteExpired() {
+	now := time.Now()
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	for key, expiry := range s.exps {
+		if now.After(expiry) {
+			delete(s.data, key)
+			delete(s.exps, key)
+		}
+	}
 }
 
 // Set writes or overwrites a key with the given value.
 func (s *Store) Set(key, value string) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
+
 	s.data[key] = value
+
+	// Also delete the expiry if any
+	delete(s.exps, key)
 }
 
 // Get returns the value and true if the key exists; otherwise (“”, false).
 func (s *Store) Get(key string) (string, bool) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
+
+	if expiry, ok := s.exps[key]; ok && time.Now().After(expiry) {
+		return "", false
+	}
+
 	v, ok := s.data[key]
+
 	return v, ok
 }
 
@@ -32,8 +98,12 @@ func (s *Store) Get(key string) (string, bool) {
 func (s *Store) Del(key string) bool {
 	s.mu.Lock()
 	defer s.mu.Unlock()
+
 	_, ok := s.data[key]
+
 	delete(s.data, key)
+	delete(s.exps, key)
+
 	return ok
 }
 
@@ -41,6 +111,51 @@ func (s *Store) Del(key string) bool {
 func (s *Store) Exists(key string) bool {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
+
+	if expiry, ok := s.exps[key]; ok && time.Now().After(expiry) {
+		return false
+	}
+
 	_, ok := s.data[key]
+
 	return ok
+}
+
+// Expire sets a TTL on an existing key. Returns true if the key exists.
+func (s *Store) Expire(key string, ttl time.Duration) bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if _, ok := s.data[key]; !ok {
+		return false
+	}
+
+	s.exps[key] = time.Now().Add(ttl)
+	return true
+}
+
+// TTL returns:
+//
+//	-2  key does not exist
+//	-1  key exists but has no associated expiration
+//	>=0 seconds left to live
+func (s *Store) TTL(key string) (time.Duration, bool) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	if _, ok := s.data[key]; !ok {
+		return -2, true // Redis TTL semantic
+	}
+
+	exp, has := s.exps[key]
+	if !has {
+		return -1, true
+	}
+
+	left := time.Until(exp)
+	if left < 0 {
+		return 0, true
+	}
+
+	return left, true
 }

--- a/internal/storage/store_test.go
+++ b/internal/storage/store_test.go
@@ -3,6 +3,7 @@ package storage
 import (
 	"sync"
 	"testing"
+	"time"
 )
 
 func TestBasicCRUD(t *testing.T) {
@@ -29,6 +30,76 @@ func TestBasicCRUD(t *testing.T) {
 	}
 	if s.Exists("k") {
 		t.Fatal("key should be gone")
+	}
+}
+
+func TestExpirationBlackBox(t *testing.T) {
+	s := New()
+	defer s.Shutdown()
+
+	// 1. key with 50 ms TTL
+	s.Set("k", "v")
+	s.Expire("k", 50*time.Millisecond)
+
+	// immediately
+	if v, ok := s.Get("k"); !ok || v != "v" {
+		t.Errorf("expected v, got %q %v", v, ok)
+	}
+	if ttl, _ := s.TTL("k"); ttl <= 0 || ttl > 50*time.Millisecond {
+		t.Errorf("bad initial ttl: %v", ttl)
+	}
+
+	// 2. wait > TTL so janitor can run at least once
+	time.Sleep(150 * time.Millisecond)
+
+	// key must be gone
+	if _, ok := s.Get("k"); ok {
+		t.Error("key should be expired and deleted")
+	}
+	if ttl, _ := s.TTL("k"); ttl != -2 {
+		t.Errorf("expected TTL -2, got %v", ttl)
+	}
+}
+
+func TestExpireOverwrite(t *testing.T) {
+	s := New()
+	defer s.Shutdown()
+
+	s.Set("k", "v")
+	s.Expire("k", 200*time.Millisecond)
+
+	// shorten expiry
+	s.Expire("k", 50*time.Millisecond)
+
+	time.Sleep(100 * time.Millisecond)
+	if _, ok := s.Get("k"); ok {
+		t.Error("key should be gone after shortened expiry")
+	}
+}
+
+func TestManyExpirations(t *testing.T) {
+	s := New()
+	defer s.Shutdown()
+
+	// insert 26 keys with staggered TTL
+	for r := 'a'; r <= 'z'; r++ {
+		key := "k" + string(r)
+		s.Set(key, "v")
+		s.Expire(key, time.Duration(r-'a'+1)*20*time.Millisecond)
+	}
+
+	// sleep until half are expired
+	time.Sleep(300 * time.Millisecond)
+
+	count := 0
+	for r := 'a'; r <= 'z'; r++ {
+		if s.Exists("k" + string(r)) {
+			count++
+		}
+	}
+	// roughly 13 left; allow ±3 for scheduling jitter
+	if count < 10 || count > 16 {
+		t.Errorf("expected ~13 keys left, got %d", count)
 	}
 }
 


### PR DESCRIPTION
## What changed
- `internal/storage/store.go`
  - new fields: `exps map[string]time.Time` + `stopJanitor chan struct{}`
  - `New()` starts background janitor (100 ms ticker) automatically
  - public methods: `Expire`, `TTL` with Redis semantics (-2 absent, -1 no expiry, ≥0 seconds left)
  - `Get`/`Exists` ignore expired keys even before janitor cleans them
  - `Shutdown()` stops goroutine cleanly (idempotent)

- `internal/storage/store_test.go`
  - black-box table tests using only public APIs
  - sleeps ≤150 ms to let real janitor run
  - covers single key, overwritten expiry, 26-key bulk run

## Verification
```make test``` - all green  
No RESP exposure yet; that comes in the next PR (TTL/EXPIRE commands).

Closes #45 