### PR TITLE
fix: made the waiting time longer

### DIFF
--- a/internal/storage/store_test.go
+++ b/internal/storage/store_test.go
@@ -132,7 +132,7 @@ func TestExpirationRealClock(t *testing.T) {
 	s.Set("k", "v")
 	s.Expire("k", 50*time.Millisecond)
 
-	time.Sleep(100 * time.Millisecond) // wait > TTL + janitor tick
+	time.Sleep(200 * time.Millisecond) // wait > TTL + janitor tick
 
 	if _, ok := s.Get("k"); ok {
 		t.Error("key should be expired")


### PR DESCRIPTION
In the previous PR the tests didn't pass because the waiting time was exactly 100ms (which is the same as the janitor waiting time), and janitor didn't work, so I changed the `store_test.go` I changed the waiting time from 100ms to 200ms to make sure all the tests pass