### PR TITLE
test: capture baseline benchmarks

### DIFF
--- a/bench/redis-v1.txt
+++ b/bench/redis-v1.txt
@@ -1,0 +1,99 @@
+ SET: rps=0.0 (overall: -nan) avg_msec=-nan (overall: -nan)                                                           SET: rps=238628.0 (overall: 238628.0) avg_msec=0.112 (overall: 0.112)                                                                      ====== SET ======
+  100000 requests completed in 0.42 seconds
+  50 parallel clients
+  3 bytes payload
+  keep alive: 1
+  multi-thread: no
+
+Latency by percentile distribution:
+0.000% <= 0.007 milliseconds (cumulative count 1)
+50.000% <= 0.103 milliseconds (cumulative count 63363)
+75.000% <= 0.119 milliseconds (cumulative count 78757)
+87.500% <= 0.159 milliseconds (cumulative count 88936)
+93.750% <= 0.183 milliseconds (cumulative count 94280)
+96.875% <= 0.199 milliseconds (cumulative count 96991)
+98.438% <= 0.223 milliseconds (cumulative count 98548)
+99.219% <= 0.311 milliseconds (cumulative count 99232)
+99.609% <= 0.551 milliseconds (cumulative count 99614)
+99.805% <= 0.799 milliseconds (cumulative count 99809)
+99.902% <= 0.935 milliseconds (cumulative count 99904)
+99.951% <= 1.039 milliseconds (cumulative count 99954)
+99.976% <= 1.095 milliseconds (cumulative count 99979)
+99.988% <= 1.135 milliseconds (cumulative count 99990)
+99.994% <= 1.167 milliseconds (cumulative count 99994)
+99.997% <= 1.223 milliseconds (cumulative count 99998)
+99.998% <= 1.247 milliseconds (cumulative count 99999)
+99.999% <= 1.263 milliseconds (cumulative count 100000)
+100.000% <= 1.263 milliseconds (cumulative count 100000)
+
+Cumulative distribution of latencies:
+63.363% <= 0.103 milliseconds (cumulative count 63363)
+97.736% <= 0.207 milliseconds (cumulative count 97736)
+99.203% <= 0.303 milliseconds (cumulative count 99203)
+99.459% <= 0.407 milliseconds (cumulative count 99459)
+99.582% <= 0.503 milliseconds (cumulative count 99582)
+99.645% <= 0.607 milliseconds (cumulative count 99645)
+99.711% <= 0.703 milliseconds (cumulative count 99711)
+99.813% <= 0.807 milliseconds (cumulative count 99813)
+99.890% <= 0.903 milliseconds (cumulative count 99890)
+99.941% <= 1.007 milliseconds (cumulative count 99941)
+99.980% <= 1.103 milliseconds (cumulative count 99980)
+99.995% <= 1.207 milliseconds (cumulative count 99995)
+100.000% <= 1.303 milliseconds (cumulative count 100000)
+
+Summary:
+  throughput summary: 240384.61 requests per second
+  latency summary (msec):
+          avg       min       p50       p95       p99       max
+        0.111     0.000     0.103     0.191     0.263     1.263
+ GET: rps=86757.0 (overall: 256188.2) avg_msec=0.104 (overall: 0.104)                                                                     GET: rps=266448.0 (overall: 263844.8) avg_msec=0.099 (overall: 0.100)                                                                      ====== GET ======
+  100000 requests completed in 0.38 seconds
+  50 parallel clients
+  3 bytes payload
+  keep alive: 1
+  multi-thread: no
+
+Latency by percentile distribution:
+0.000% <= 0.015 milliseconds (cumulative count 7)
+50.000% <= 0.095 milliseconds (cumulative count 60412)
+75.000% <= 0.103 milliseconds (cumulative count 80200)
+87.500% <= 0.111 milliseconds (cumulative count 88435)
+93.750% <= 0.135 milliseconds (cumulative count 94574)
+96.875% <= 0.175 milliseconds (cumulative count 97352)
+98.438% <= 0.199 milliseconds (cumulative count 98474)
+99.219% <= 0.255 milliseconds (cumulative count 99242)
+99.609% <= 0.407 milliseconds (cumulative count 99612)
+99.805% <= 0.663 milliseconds (cumulative count 99810)
+99.902% <= 0.823 milliseconds (cumulative count 99904)
+99.951% <= 1.151 milliseconds (cumulative count 99952)
+99.976% <= 1.279 milliseconds (cumulative count 99978)
+99.988% <= 1.327 milliseconds (cumulative count 99991)
+99.994% <= 1.351 milliseconds (cumulative count 99995)
+99.997% <= 1.375 milliseconds (cumulative count 99997)
+99.998% <= 1.431 milliseconds (cumulative count 99999)
+99.999% <= 1.479 milliseconds (cumulative count 100000)
+100.000% <= 1.479 milliseconds (cumulative count 100000)
+
+Cumulative distribution of latencies:
+80.200% <= 0.103 milliseconds (cumulative count 80200)
+98.692% <= 0.207 milliseconds (cumulative count 98692)
+99.448% <= 0.303 milliseconds (cumulative count 99448)
+99.612% <= 0.407 milliseconds (cumulative count 99612)
+99.724% <= 0.503 milliseconds (cumulative count 99724)
+99.782% <= 0.607 milliseconds (cumulative count 99782)
+99.838% <= 0.703 milliseconds (cumulative count 99838)
+99.894% <= 0.807 milliseconds (cumulative count 99894)
+99.919% <= 0.903 milliseconds (cumulative count 99919)
+99.926% <= 1.007 milliseconds (cumulative count 99926)
+99.943% <= 1.103 milliseconds (cumulative count 99943)
+99.966% <= 1.207 milliseconds (cumulative count 99966)
+99.980% <= 1.303 milliseconds (cumulative count 99980)
+99.998% <= 1.407 milliseconds (cumulative count 99998)
+100.000% <= 1.503 milliseconds (cumulative count 100000)
+
+Summary:
+  throughput summary: 265957.47 requests per second
+  latency summary (msec):
+          avg       min       p50       p95       p99       max
+        0.100     0.008     0.095     0.143     0.231     1.479
+

--- a/bench/v1.txt
+++ b/bench/v1.txt
@@ -1,0 +1,10 @@
+goos: linux
+goarch: amd64
+pkg: github.com/DarsenOP/Rift/internal/storage
+cpu: 13th Gen Intel(R) Core(TM) i9-13980HX
+BenchmarkSet-32        	 5161022	       252.6 ns/op	     154 B/op	       2 allocs/op
+BenchmarkGetHit-32     	88412450	        14.39 ns/op	       0 B/op	       0 allocs/op
+BenchmarkGetMiss-32    	100000000	        10.85 ns/op	       0 B/op	       0 allocs/op
+BenchmarkExpire-32     	 2480557	       513.8 ns/op	     313 B/op	       2 allocs/op
+PASS
+ok  	github.com/DarsenOP/Rift/internal/storage	6.478s

--- a/docs/bench/redis-v1.md
+++ b/docs/bench/redis-v1.md
@@ -1,0 +1,21 @@
+# Redis-Benchmark Stress Test 
+
+**Hardware:** 13th Gen Intel i9-13980HX, 32 cores  
+**Go:** 1.24 linux/amd64  
+**Tool:** redis-benchmark 7.2.4 (single-core, 50 clients, 100 k ops each)  
+**Date:** 2025-09-04
+
+## Summary
+
+| Command | Ops/sec | p50 (ms) | p99 (ms) | max (ms) |
+|---------|--------:|---------:|---------:|---------:|
+| **SET** | 240 385 |    0.103 |    0.263 |    1.263 |
+| **GET** | 265 957 |    0.095 |    0.231 |    1.479 |
+
+## Observations
+
+- Zero panics, zero goroutine leaks (`go test -race` clean)  
+- Global RWMutex handles 250 k ops/s single-core without contention collapse  
+- Latency distribution tight: 99 % of ops < 0.3 ms  
+- Reads slightly faster (no write-lock) – expected  
+- Baseline captured; future sharding or lock-striping will be measured against these numbers

--- a/docs/bench/v1.md
+++ b/docs/bench/v1.md
@@ -1,0 +1,21 @@
+# Benchmark Baseline
+
+**goos**: linux
+**goarch**: amd64
+**pkg**: github.com/DarsenOP/Rift/internal/storage
+**cpu**: 13th Gen Intel(R) Core(TM) i9-13980HX
+
+BenchmarkSet-32        	 5161022	       252.6 ns/op	     154 B/op	       2 allocs/op
+BenchmarkGetHit-32     	88412450	        14.39 ns/op	       0 B/op	       0 allocs/op
+BenchmarkGetMiss-32    	100000000	        10.85 ns/op	       0 B/op	       0 allocs/op
+BenchmarkExpire-32     	 2480557	       513.8 ns/op	     313 B/op	       2 allocs/op
+
+PASS
+ok  	github.com/DarsenOP/Rift/internal/storage	6.478s
+
+
+## Observations
+- Reads scale perfectly (0 allocs, ~11-14 ns) – global RWMutex hot-path is fine  
+- Writes at 4 M ops/s single-core – acceptable for clone baseline  
+- Expire adds 313 B for `time.Time` – negligible, can be optimised later  
+- Numbers captured; future sharding or lock-striping will be measured against this run

--- a/docs/bench/v1.md
+++ b/docs/bench/v1.md
@@ -1,9 +1,14 @@
 # Benchmark Baseline
 
-**goos**: linux
-**goarch**: amd64
-**pkg**: github.com/DarsenOP/Rift/internal/storage
-**cpu**: 13th Gen Intel(R) Core(TM) i9-13980HX
+**Hardware:** 13th Gen Intel i9-13980HX, 32 cores  
+**Go:** 1.24 linux/amd64  
+**Date:** 2025-09-04
+
+```bash
+goos: linux
+goarch: amd64
+pkg: github.com/DarsenOP/Rift/internal/storage
+cpu: 13th Gen Intel(R) Core(TM) i9-13980HX
 
 BenchmarkSet-32        	 5161022	       252.6 ns/op	     154 B/op	       2 allocs/op
 BenchmarkGetHit-32     	88412450	        14.39 ns/op	       0 B/op	       0 allocs/op
@@ -12,7 +17,7 @@ BenchmarkExpire-32     	 2480557	       513.8 ns/op	     313 B/op	       2 alloc
 
 PASS
 ok  	github.com/DarsenOP/Rift/internal/storage	6.478s
-
+```
 
 ## Observations
 - Reads scale perfectly (0 allocs, ~11-14 ns) – global RWMutex hot-path is fine  

--- a/internal/storage/store_bench_test.go
+++ b/internal/storage/store_bench_test.go
@@ -1,0 +1,46 @@
+package storage
+
+import (
+	"fmt"
+	"testing"
+	"time"
+)
+
+func BenchmarkSet(b *testing.B) {
+	s := New()
+	defer s.Shutdown()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		s.Set(fmt.Sprintf("key%d", i), "value")
+	}
+}
+
+func BenchmarkGetHit(b *testing.B) {
+	s := New()
+	defer s.Shutdown()
+	s.Set("k", "v")
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, _ = s.Get("k")
+	}
+}
+
+func BenchmarkGetMiss(b *testing.B) {
+	s := New()
+	defer s.Shutdown()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, _ = s.Get("missing")
+	}
+}
+
+func BenchmarkExpire(b *testing.B) {
+	s := New()
+	defer s.Shutdown()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		key := fmt.Sprintf("k%d", i)
+		s.Set(key, "v")
+		s.Expire(key, 10*time.Second)
+	}
+}


### PR DESCRIPTION
## Summary
Adds micro-benchmarks and redis-benchmark stress numbers for the current single-lock storage engine.

## What's included
- `internal/storage/store_bench_test.go`
  - `BenchmarkSet`, `BenchmarkGetHit`, `BenchmarkGetMiss`, `BenchmarkExpire`
- `docs/bench/v1.md` & `docs/bench/redis-v1.md`
  - Full redis-benchmark output (SET 240 k ops/s, GET 266 k ops/s)
  - Latency percentiles and observations

## Results snapshot
| op     | ops/sec | p50 (ms) | p99 (ms) |
|--------|--------:|---------:|---------:|
| SET    | 240 385 |    0.103 |    0.263 |
| GET    | 265 957 |    0.095 |    0.231 |

Zero panics, zero goroutine leaks, global RWMutex baseline captured for future comparison.