### PR TITLE
feat: added the list commands

### DIFF
--- a/cmd/rift/main.go
+++ b/cmd/rift/main.go
@@ -81,6 +81,7 @@ func main() {
 
 func handleConnection(conn net.Conn) {
 	store := storage.New()
+	defer store.Shutdown()
 
 	defer func() {
 		if r := recover(); r != nil {

--- a/internal/server/commands_list.go
+++ b/internal/server/commands_list.go
@@ -1,0 +1,171 @@
+package server
+
+import (
+	"strconv"
+
+	"github.com/DarsenOP/Rift/internal/resp"
+	"github.com/DarsenOP/Rift/internal/storage"
+)
+
+func HandleLPUSH(store *storage.Store, args []resp.Value) resp.Value {
+	if len(args) < 2 {
+		return resp.Value{Typ: "error", Str: "ERR wrong number of arguments for 'LPUSH' command"}
+	}
+
+	key := args[0].Str
+	values := make([]string, len(args)-1)
+	for i, arg := range args[1:] {
+		if arg.Typ != "bulk" {
+			return resp.Value{Typ: "error", Str: "ERR arguments should be bulk strings"}
+		}
+		values[i] = arg.Str
+	}
+
+	length, err := store.LPush(key, values...)
+	if err != nil {
+		if err == storage.ErrWrongType {
+			return resp.Value{Typ: "error", Str: "WRONGTYPE Operation against a key holding the wrong kind of value"}
+		}
+		return resp.Value{Typ: "error", Str: "ERR " + err.Error()}
+	}
+
+	return resp.Value{Typ: "integer", Num: length}
+}
+
+func HandleRPUSH(store *storage.Store, args []resp.Value) resp.Value {
+	if len(args) < 2 {
+		return resp.Value{Typ: "error", Str: "ERR wrong number of arguments for 'RPUSH' command"}
+	}
+
+	key := args[0].Str
+	values := make([]string, len(args)-1)
+	for i, arg := range args[1:] {
+		if arg.Typ != "bulk" {
+			return resp.Value{Typ: "error", Str: "ERR arguments should be bulk strings"}
+		}
+		values[i] = arg.Str
+	}
+
+	length, err := store.RPush(key, values...)
+	if err != nil {
+		if err == storage.ErrWrongType {
+			return resp.Value{Typ: "error", Str: "WRONGTYPE Operation against a key holding the wrong kind of value"}
+		}
+		return resp.Value{Typ: "error", Str: "ERR " + err.Error()}
+	}
+
+	return resp.Value{Typ: "integer", Num: length}
+}
+
+func HandleLPOP(store *storage.Store, args []resp.Value) resp.Value {
+	if len(args) != 1 {
+		return resp.Value{Typ: "error", Str: "ERR wrong number of arguments for 'LPOP' command"}
+	}
+
+	if args[0].Typ != "bulk" {
+		return resp.Value{Typ: "error", Str: "ERR argument should be a bulk string"}
+	}
+
+	value, err := store.LPop(args[0].Str)
+	if err != nil {
+		if err == storage.ErrWrongType {
+			return resp.Value{Typ: "error", Str: "WRONGTYPE Operation against a key holding the wrong kind of value"}
+		}
+		if err == storage.ErrNotFound {
+			return resp.Value{Typ: "null", NullTyp: "bulk"} // Redis returns nil for non-existent keys
+		}
+		return resp.Value{Typ: "error", Str: "ERR " + err.Error()}
+	}
+
+	if value == "" {
+		return resp.Value{Typ: "null", NullTyp: "bulk"}
+	}
+
+	return resp.Value{Typ: "bulk", Str: value}
+}
+
+func HandleRPOP(store *storage.Store, args []resp.Value) resp.Value {
+	if len(args) != 1 {
+		return resp.Value{Typ: "error", Str: "ERR wrong number of arguments for 'RPOP' command"}
+	}
+
+	if args[0].Typ != "bulk" {
+		return resp.Value{Typ: "error", Str: "ERR argument should be a bulk string"}
+	}
+
+	value, err := store.RPop(args[0].Str)
+	if err != nil {
+		if err == storage.ErrWrongType {
+			return resp.Value{Typ: "error", Str: "WRONGTYPE Operation against a key holding the wrong kind of value"}
+		}
+		if err == storage.ErrNotFound {
+			return resp.Value{Typ: "null", NullTyp: "bulk"} // Redis returns nil for non-existent keys
+		}
+		return resp.Value{Typ: "error", Str: "ERR " + err.Error()}
+	}
+
+	if value == "" {
+		return resp.Value{Typ: "null", NullTyp: "bulk"}
+	}
+
+	return resp.Value{Typ: "bulk", Str: value}
+}
+
+func HandleLRANGE(store *storage.Store, args []resp.Value) resp.Value {
+	if len(args) != 3 {
+		return resp.Value{Typ: "error", Str: "ERR wrong number of arguments for 'LRANGE' command"}
+	}
+
+	if args[0].Typ != "bulk" || args[1].Typ != "bulk" || args[2].Typ != "bulk" {
+		return resp.Value{Typ: "error", Str: "ERR arguments should be bulk strings"}
+	}
+
+	start, err1 := strconv.Atoi(args[1].Str)
+	stop, err2 := strconv.Atoi(args[2].Str)
+
+	if err1 != nil || err2 != nil {
+		return resp.Value{Typ: "error", Str: "ERR value is not an integer or out of range"}
+	}
+
+	elements, err := store.LRange(args[0].Str, start, stop)
+	if err != nil {
+		if err == storage.ErrWrongType {
+			return resp.Value{Typ: "error", Str: "WRONGTYPE Operation against a key holding the wrong kind of value"}
+		}
+		if err == storage.ErrNotFound {
+			return resp.Value{Typ: "array", Array: []resp.Value{}} // Redis returns empty array for non-existent keys
+		}
+		return resp.Value{Typ: "error", Str: "ERR " + err.Error()}
+	}
+
+	// Build RESP array response
+	respArray := make([]resp.Value, len(elements))
+	for i, element := range elements {
+		respArray[i] = resp.Value{Typ: "bulk", Str: element}
+	}
+
+	return resp.Value{Typ: "array", Array: respArray}
+}
+
+func HandleLLEN(store *storage.Store, args []resp.Value) resp.Value {
+	if len(args) != 1 {
+		return resp.Value{Typ: "error", Str: "ERR wrong number of arguments for 'LLEN' command"}
+	}
+
+	if args[0].Typ != "bulk" {
+		return resp.Value{Typ: "error", Str: "ERR argument should be a bulk string"}
+	}
+
+	length, err := store.LLen(args[0].Str)
+	if err != nil {
+		if err == storage.ErrWrongType {
+			return resp.Value{Typ: "error", Str: "WRONGTYPE Operation against a key holding the wrong kind of value"}
+		}
+		if err == storage.ErrNotFound {
+			return resp.Value{Typ: "integer", Num: 0} // Redis returns 0 for non-existent keys
+		}
+		return resp.Value{Typ: "error", Str: "ERR " + err.Error()}
+	}
+
+	return resp.Value{Typ: "integer", Num: length}
+}

--- a/internal/server/handler.go
+++ b/internal/server/handler.go
@@ -40,6 +40,18 @@ func HandleCommand(store *storage.Store, value resp.Value) resp.Value {
 		return HandleTTL(store, value.Array[1:])
 	case "EXPIRE":
 		return HandleEXPIRE(store, value.Array[1:])
+	case "LPUSH":
+		return HandleLPUSH(store, value.Array[1:])
+	case "RPUSH":
+		return HandleRPUSH(store, value.Array[1:])
+	case "LPOP":
+		return HandleLPOP(store, value.Array[1:])
+	case "RPOP":
+		return HandleRPOP(store, value.Array[1:])
+	case "LRANGE":
+		return HandleLRANGE(store, value.Array[1:])
+	case "LLEN":
+		return HandleLLEN(store, value.Array[1:])
 	default:
 		return resp.Value{Typ: "error", Str: "ERR unknown command '" + command.Str + "'"}
 	}

--- a/internal/server/handler_test.go
+++ b/internal/server/handler_test.go
@@ -369,7 +369,216 @@ func TestHandleCommand(t *testing.T) {
 		},
 	}
 
+	listTests := []struct {
+		name     string
+		input    resp.Value
+		expected resp.Value
+	}{
+		{
+			name: "LPUSH new list",
+			input: resp.Value{
+				Typ: "array",
+				Array: []resp.Value{
+					{Typ: "bulk", Str: "LPUSH"},
+					{Typ: "bulk", Str: "mylist"},
+					{Typ: "bulk", Str: "world"},
+				},
+			},
+			expected: resp.Value{Typ: "integer", Num: 1},
+		},
+		{
+			name: "LPUSH multiple values",
+			input: resp.Value{
+				Typ: "array",
+				Array: []resp.Value{
+					{Typ: "bulk", Str: "LPUSH"},
+					{Typ: "bulk", Str: "mylist"},
+					{Typ: "bulk", Str: "hello"},
+				},
+			},
+			expected: resp.Value{Typ: "integer", Num: 2},
+		},
+		{
+			name: "LRANGE full list",
+			input: resp.Value{
+				Typ: "array",
+				Array: []resp.Value{
+					{Typ: "bulk", Str: "LRANGE"},
+					{Typ: "bulk", Str: "mylist"},
+					{Typ: "bulk", Str: "0"},
+					{Typ: "bulk", Str: "-1"},
+				},
+			},
+			expected: resp.Value{
+				Typ: "array",
+				Array: []resp.Value{
+					{Typ: "bulk", Str: "hello"},
+					{Typ: "bulk", Str: "world"},
+				},
+			},
+		},
+		{
+			name: "LLEN existing list",
+			input: resp.Value{
+				Typ: "array",
+				Array: []resp.Value{
+					{Typ: "bulk", Str: "LLEN"},
+					{Typ: "bulk", Str: "mylist"},
+				},
+			},
+			expected: resp.Value{Typ: "integer", Num: 2},
+		},
+		{
+			name: "LPOP from list",
+			input: resp.Value{
+				Typ: "array",
+				Array: []resp.Value{
+					{Typ: "bulk", Str: "LPOP"},
+					{Typ: "bulk", Str: "mylist"},
+				},
+			},
+			expected: resp.Value{Typ: "bulk", Str: "hello"},
+		},
+		{
+			name: "RPOP from list",
+			input: resp.Value{
+				Typ: "array",
+				Array: []resp.Value{
+					{Typ: "bulk", Str: "RPOP"},
+					{Typ: "bulk", Str: "mylist"},
+				},
+			},
+			expected: resp.Value{Typ: "bulk", Str: "world"},
+		},
+		{
+			name: "LPOP from empty list",
+			input: resp.Value{
+				Typ: "array",
+				Array: []resp.Value{
+					{Typ: "bulk", Str: "LPOP"},
+					{Typ: "bulk", Str: "mylist"},
+				},
+			},
+			expected: resp.Value{Typ: "null", NullTyp: "bulk"},
+		},
+		{
+			name: "LLEN on non-existent key",
+			input: resp.Value{
+				Typ: "array",
+				Array: []resp.Value{
+					{Typ: "bulk", Str: "LLEN"},
+					{Typ: "bulk", Str: "nonexistent"},
+				},
+			},
+			expected: resp.Value{Typ: "integer", Num: 0},
+		},
+		{
+			name: "LRANGE on non-existent key",
+			input: resp.Value{
+				Typ: "array",
+				Array: []resp.Value{
+					{Typ: "bulk", Str: "LRANGE"},
+					{Typ: "bulk", Str: "nonexistent"},
+					{Typ: "bulk", Str: "0"},
+					{Typ: "bulk", Str: "-1"},
+				},
+			},
+			expected: resp.Value{Typ: "array", Array: []resp.Value{}},
+		},
+		{
+			name: "LPUSH wrong arity",
+			input: resp.Value{
+				Typ: "array",
+				Array: []resp.Value{
+					{Typ: "bulk", Str: "LPUSH"},
+					{Typ: "bulk", Str: "mylist"},
+				},
+			},
+			expected: resp.Value{Typ: "error", Str: "ERR wrong number of arguments for 'LPUSH' command"},
+		},
+		{
+			name: "LRANGE wrong arity",
+			input: resp.Value{
+				Typ: "array",
+				Array: []resp.Value{
+					{Typ: "bulk", Str: "LRANGE"},
+					{Typ: "bulk", Str: "mylist"},
+					{Typ: "bulk", Str: "0"},
+				},
+			},
+			expected: resp.Value{Typ: "error", Str: "ERR wrong number of arguments for 'LRANGE' command"},
+		},
+		{
+			name: "LRANGE invalid indices",
+			input: resp.Value{
+				Typ: "array",
+				Array: []resp.Value{
+					{Typ: "bulk", Str: "LRANGE"},
+					{Typ: "bulk", Str: "mylist"},
+					{Typ: "bulk", Str: "abc"}, // Not integer
+					{Typ: "bulk", Str: "def"}, // Not integer
+				},
+			},
+			expected: resp.Value{Typ: "error", Str: "ERR value is not an integer or out of range"},
+		},
+		// Add these to your listTests slice:
+		{
+			name: "RPUSH new list",
+			input: resp.Value{
+				Typ: "array",
+				Array: []resp.Value{
+					{Typ: "bulk", Str: "RPUSH"},
+					{Typ: "bulk", Str: "mylist2"},
+					{Typ: "bulk", Str: "hello"},
+				},
+			},
+			expected: resp.Value{Typ: "integer", Num: 1},
+		},
+		{
+			name: "RPUSH multiple values",
+			input: resp.Value{
+				Typ: "array",
+				Array: []resp.Value{
+					{Typ: "bulk", Str: "RPUSH"},
+					{Typ: "bulk", Str: "mylist2"},
+					{Typ: "bulk", Str: "world"},
+				},
+			},
+			expected: resp.Value{Typ: "integer", Num: 2},
+		},
+		{
+			name: "LRANGE RPUSH result",
+			input: resp.Value{
+				Typ: "array",
+				Array: []resp.Value{
+					{Typ: "bulk", Str: "LRANGE"},
+					{Typ: "bulk", Str: "mylist2"},
+					{Typ: "bulk", Str: "0"},
+					{Typ: "bulk", Str: "-1"},
+				},
+			},
+			expected: resp.Value{
+				Typ: "array",
+				Array: []resp.Value{
+					{Typ: "bulk", Str: "hello"},
+					{Typ: "bulk", Str: "world"},
+				},
+			},
+		},
+	}
+
 	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := HandleCommand(store, tt.input)
+
+			if !valuesEqual(result, tt.expected) {
+				t.Errorf("HandleCommand() = %+v, want %+v", result, tt.expected)
+			}
+		})
+	}
+
+	// Run the list tests
+	for _, tt := range listTests {
 		t.Run(tt.name, func(t *testing.T) {
 			result := HandleCommand(store, tt.input)
 

--- a/internal/storage/utils.go
+++ b/internal/storage/utils.go
@@ -11,16 +11,16 @@ var (
 )
 
 // Type checking utilities
-// func (s *Store) checkType(key string, expected DataType) (*Value, error) {
-// 	value, exists := s.data[key]
-// 	if !exists {
-// 		return nil, ErrNotFound
-// 	}
-// 	if value.Type != expected {
-// 		return nil, ErrWrongType
-// 	}
-// 	return value, nil
-// }
+func (s *Store) checkType(key string, expected DataType) (*Value, error) {
+	value, exists := s.data[key]
+	if !exists {
+		return nil, ErrNotFound
+	}
+	if value.Type != expected {
+		return nil, ErrWrongType
+	}
+	return value, nil
+}
 
 // Expiration utilities
 func setExpiry(value *Value, ttl time.Duration) {


### PR DESCRIPTION
## What

This PR merges the already-reviewed list-commands branch into advanced-commands, giving the latter a stable foundation that contains:

- RESP2 list operations: LPUSH, RPUSH, LPOP, RPOP, LRANGE, LLEN
- Full arity, type-checking and Redis-compatible replies
- Unit tests and benchmarks for every command

## Why

advanced-commands is intended to become the long-lived feature branch for Hash, Set, Sorted-Set, etc.
Starting from the list implementation keeps the diff small and avoids rebasing pain later.