### PR TITLE
feat: added the type commands

### DIFF
--- a/internal/server/commands_type.go
+++ b/internal/server/commands_type.go
@@ -1,0 +1,48 @@
+package server
+
+import (
+	"github.com/DarsenOP/Rift/internal/resp"
+	"github.com/DarsenOP/Rift/internal/storage"
+)
+
+func HandleTYPE(s *storage.Store, args []resp.Value) resp.Value {
+	if len(args) != 1 || args[0].Typ != "bulk" {
+		return resp.Value{Typ: "error", Str: "ERR wrong number of arguments for 'TYPE' command"}
+	}
+	t := s.Type(args[0].Str)
+	return resp.Value{Typ: "bulk", Str: t}
+}
+
+func HandleRENAME(s *storage.Store, args []resp.Value) resp.Value {
+	if len(args) != 2 || args[0].Typ != "bulk" || args[1].Typ != "bulk" {
+		return resp.Value{Typ: "error", Str: "ERR wrong number of arguments for 'RENAME' command"}
+	}
+	if err := s.Rename(args[0].Str, args[1].Str); err != nil {
+		if err == storage.ErrNotFound {
+			return resp.Value{Typ: "error", Str: "ERR no such key"}
+		}
+		return resp.Value{Typ: "error", Str: "ERR " + err.Error()}
+	}
+	return resp.Value{Typ: "simple", Str: "OK"}
+}
+
+func HandleRENAMENX(s *storage.Store, args []resp.Value) resp.Value {
+	if len(args) != 2 || args[0].Typ != "bulk" || args[1].Typ != "bulk" {
+		return resp.Value{Typ: "error", Str: "ERR wrong number of arguments for 'RENAMENX' command"}
+	}
+	ok, err := s.RenameNX(args[0].Str, args[1].Str)
+	if err != nil {
+		if err == storage.ErrNotFound {
+			return resp.Value{Typ: "error", Str: "ERR no such key"}
+		}
+		return resp.Value{Typ: "error", Str: "ERR " + err.Error()}
+	}
+	return resp.Value{Typ: "integer", Num: boolToInt(ok)}
+}
+
+func boolToInt(b bool) int {
+	if b {
+		return 1
+	}
+	return 0
+}

--- a/internal/server/handler.go
+++ b/internal/server/handler.go
@@ -76,6 +76,12 @@ func HandleCommand(store *storage.Store, value resp.Value) resp.Value {
 		return HandleSCARD(store, value.Array[1:])
 	case "SINTER":
 		return HandleSINTER(store, value.Array[1:])
+	case "TYPE":
+		return HandleTYPE(store, value.Array[1:])
+	case "RENAME":
+		return HandleRENAME(store, value.Array[1:])
+	case "RENAMENX":
+		return HandleRENAMENX(store, value.Array[1:])
 	default:
 		return resp.Value{Typ: "error", Str: "ERR unknown command '" + command.Str + "'"}
 	}


### PR DESCRIPTION
## What

This PR merges the already-reviewed type-commands branch into advanced-commands, giving the latter a stable foundation that contains:

- RESP2 hash operations: TYPE, RENAME, RENAMENX
- Full arity, type-checking and Redis-compatible replies
- Unit tests and benchmarks for every command

## Why

advanced-commands is intended to become the long-lived feature branch for Hash, Set, Sorted-Set, etc. 